### PR TITLE
Check CUDA_ROOT/compute-sanitizer for nvHPC

### DIFF
--- a/src/CUDA_Runtime_Discovery.jl
+++ b/src/CUDA_Runtime_Discovery.jl
@@ -247,10 +247,16 @@ function find_cuda_binary(toolkit_dirs::Vector{String}, name::String)
     # figure out the location
     locations = toolkit_dirs
     ## compute-sanitizer is in the "extras" directory of the toolkit
+    ## NVHPC has it in the top-level directory
     if name == "compute-sanitizer"
         toolkit_extras_dirs = filter(dir->isdir(joinpath(dir, "extras")), toolkit_dirs)
         sanitizer_dirs = map(dir->joinpath(dir, "extras", "compute-sanitizer"), toolkit_extras_dirs)
+
+        toolkit_sanitizer_dirs = filter(dir->isdir(joinpath(dir, "compute-sanitizer")), toolkit_dirs)
+        sanitizer_dirs_other =  map(dir->joinpath(dir, "compute-sanitizer"), toolkit_sanitizer_dirs)
+
         append!(locations, sanitizer_dirs)
+        append!(locations, sanitizer_dirs_other)
     end
 
     find_binary(name; locations)


### PR DESCRIPTION
With this:

```
┌ Debug: Looking for binary compute-sanitizer in /opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7 or /opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7/extras/compute-sanitizer or /opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7/compute-sanitizer
│   all_locations =
│    6-element Vector{String}:
│     "/opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7"
│     "/opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7/bin"
│     "/opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7/extras/compute-sanitizer"
│     "/opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7/extras/compute-sanitizer/bin"
│     "/opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7/compute-sanitizer"
│     "/opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7/compute-sanitizer/bin"
└ @ CUDA_Runtime_Discovery ~/.julia/packages/CUDA_Runtime_Discovery/qpeMB/src/CUDA_Runtime_Discovery.jl:156
┌ Debug: Found /opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7/compute-sanitizer/compute-sanitizer at /opt/nvidia/hpc_sdk/Linux_x86_64/22.5/cuda/11.7/compute-sanitizer/compute-sanitizer
└ @ CUDA_Runtime_Discovery ~/.julia/packages/CUDA_Runtime_Discovery/qpeMB/src/CUDA_Runtime_Discovery.jl:162
```

fixes #3 