### PR TITLE
Expand search path for HPC SDK

### DIFF
--- a/src/CUDA_Runtime_Discovery.jl
+++ b/src/CUDA_Runtime_Discovery.jl
@@ -123,6 +123,9 @@ function find_library(name::String, versions::Vector=[];
             push!(all_locations, joinpath(location, "bin"))
             push!(all_locations, joinpath(location, "bin", Sys.WORD_SIZE==64 ? "x64" : "Win32"))
         end
+        if Sys.islinux()
+            push!(all_locations, joinpath(location, "targets", "$(Sys.ARCH)-linux", "lib")) # NVHPC SDK
+        end
     end
 
     @debug "Looking for library $name, $(join_versions(versions)), $(join_locations(locations))" all_names all_locations
@@ -412,6 +415,9 @@ function find_libcudadevrt(toolkit_dirs)
             push!(all_locations, joinpath(location, "lib"))
             if Sys.WORD_SIZE == 64
                 push!(all_locations, joinpath(location, "lib64"))
+            end
+            if Sys.islinux()
+                push!(all_locations, joinpath(location, "targets", "$(Sys.ARCH)-linux", "lib")) # NVHPC SDK
             end
         end
     end

--- a/src/CUDA_Runtime_Discovery.jl
+++ b/src/CUDA_Runtime_Discovery.jl
@@ -126,7 +126,10 @@ function find_library(name::String, versions::Vector=[];
             push!(all_locations, joinpath(location, "bin", Sys.WORD_SIZE==64 ? "x64" : "Win32"))
         end
         if Sys.islinux()
-            push!(all_locations, joinpath(location, "targets", "$(Sys.ARCH)-linux", "lib")) # NVHPC SDK
+            arch = Sys.ARCH == :powerpc64le ? :ppc64le :
+                   Sys.ARCH == :aarch64 ? :sbsa :
+                   Sys.ARCH            
+            push!(all_locations, joinpath(location, "targets", "$arch-linux", "lib")) # NVHPC SDK
         end
     end
 
@@ -419,7 +422,10 @@ function find_libcudadevrt(toolkit_dirs)
                 push!(all_locations, joinpath(location, "lib64"))
             end
             if Sys.islinux()
-                push!(all_locations, joinpath(location, "targets", "$(Sys.ARCH)-linux", "lib")) # NVHPC SDK
+                arch = Sys.ARCH == :powerpc64le ? :ppc64le :
+                       Sys.ARCH == :aarch64 ? :sbsa :
+                       Sys.ARCH
+                push!(all_locations, joinpath(location, "targets", "$arch-linux", "lib")) # NVHPC SDK
             end
         end
     end

--- a/src/CUDA_Runtime_Discovery.jl
+++ b/src/CUDA_Runtime_Discovery.jl
@@ -115,9 +115,11 @@ function find_library(name::String, versions::Vector=[];
     for location in locations
         push!(all_locations, location)
         push!(all_locations, joinpath(location, "lib"))
+        push!(all_locations, joinpath(location, "nvvm", "lib"))
         if Sys.WORD_SIZE == 64
             push!(all_locations, joinpath(location, "lib64"))
             push!(all_locations, joinpath(location, "libx64"))
+            push!(all_locations, joinpath(location, "nvvm", "lib64"))
         end
         if Sys.iswindows()
             push!(all_locations, joinpath(location, "bin"))


### PR DESCRIPTION
Fixes #5.

I've tested this on our cluster, and it is able to find all files by setting `CUDA_HOME` (i.e. without needing `LD_LIBRARY_PATH` set)