### PR TITLE
Restore finding nvvm for `CUDA_Compiler_jll`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CUDA_Runtime_Discovery"
 uuid = "1af6417a-86b4-443c-805f-a4643ffb695f"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "2.0.0"
+version = "2.1.0"
 
 [deps]
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/src/CUDA_Runtime_Discovery.jl
+++ b/src/CUDA_Runtime_Discovery.jl
@@ -543,13 +543,13 @@ is_available() = available[]
 
 export ptxas, nvdisasm, nvlink,
        libcudadevrt, libdevice,
-       libcudart, libcupti, libnvperf_host, libnvperf_target,
+       libcudart, libcupti, libnvperf_host, libnvperf_target, libnvvm,
        libcufft, libcublas, libcublasLt, libcusparse, libcusolver, libcusolverMg, libcurand
 
 function __init__()
     dirs = find_toolkit()
+    print("WOW $(dirs)")
     isempty(dirs) && return
-
     try
         # binaries
         global ptxas_path = get_binary(dirs, "ptxas")
@@ -568,6 +568,7 @@ function __init__()
         global libcupti = get_library(dirs, "cupti")
         global libnvperf_host = get_library(dirs, "nvperf_host")
         global libnvperf_target = get_library(dirs, "nvperf_target")
+        global libnvvm = get_libarary(dirs, "nvvm")
 
         # files
         global libcudadevrt = get_libcudadevrt(dirs)

--- a/src/CUDA_Runtime_Discovery.jl
+++ b/src/CUDA_Runtime_Discovery.jl
@@ -548,7 +548,6 @@ export ptxas, nvdisasm, nvlink,
 
 function __init__()
     dirs = find_toolkit()
-    print("WOW $(dirs)")
     isempty(dirs) && return
     try
         # binaries
@@ -568,7 +567,7 @@ function __init__()
         global libcupti = get_library(dirs, "cupti")
         global libnvperf_host = get_library(dirs, "nvperf_host")
         global libnvperf_target = get_library(dirs, "nvperf_target")
-        global libnvvm = get_libarary(dirs, "nvvm")
+        global libnvvm = get_library(dirs, "nvvm")
 
         # files
         global libcudadevrt = get_libcudadevrt(dirs)


### PR DESCRIPTION
Not exporting libnvvm from `CUDA_Runtime_Discovery` means AOT compiled packages break when using CUDA.

~~Bumped minor version, but @maleadt you know better whether this is breaking or "just a bugfix"~~ It is breaking, exports changed. Bumping to 3.0.0